### PR TITLE
Wrap nkAwbInit inside document.ready

### DIFF
--- a/src/assets/awb/awb.js
+++ b/src/assets/awb/awb.js
@@ -623,9 +623,13 @@ window.nkAwbInit = function() {
 };
 
 // init awb.
-window.nkAwbInit();
-const throttledInitAwb = throttle( 200, () => {
+$( document ).ready( () => {
     window.nkAwbInit();
+} );
+const throttledInitAwb = throttle( 200, () => {
+    $( document ).ready( () => {
+        window.nkAwbInit();
+    } );
 } );
 if ( window.MutationObserver ) {
     new window.MutationObserver( throttledInitAwb )


### PR DESCRIPTION
```
$( document ).ready( () => {
        window.nkAwbInit();
} );
```

Fixes #48 