### PR TITLE
chore(deps): bump jarallax and video-worker to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "advanced-backgrounds",
-  "version": "1.12.10",
+  "version": "1.12.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "advanced-backgrounds",
-      "version": "1.12.10",
+      "version": "1.12.11",
       "hasInstallScript": true,
       "license": "GPL-2.0",
       "dependencies": {
@@ -14,10 +14,10 @@
         "conditionize": "^1.0.5",
         "deep-assign": "^3.0.0",
         "deep-equal": "^2.2.3",
-        "jarallax": "^3.0.1",
+        "jarallax": "^3.1.0",
         "shorthash": "0.0.2",
         "throttle-debounce": "^5.0.2",
-        "video-worker": "^3.0.1"
+        "video-worker": "^3.1.0"
       },
       "devDependencies": {
         "@babel/node": "^7.29.0",
@@ -10836,12 +10836,12 @@
       }
     },
     "node_modules/jarallax": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jarallax/-/jarallax-3.0.1.tgz",
-      "integrity": "sha512-CipllEQw7vGt5Mz1bDCoP+1izyoakI6TUuyGIhFJAzP/91FGYVvKlGIY6Ijq3zwxkwJlweezduAvys9RsxcqZA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jarallax/-/jarallax-3.1.0.tgz",
+      "integrity": "sha512-tO6N/CRcB4OXLMm+ZkuKcuVNXzbhU2SS6gziaPczk3zuVuiUKxYZrL9wrdqmV7lgwGoyu6EUOpvWMgqi8eSCTA==",
       "license": "MIT",
       "dependencies": {
-        "video-worker": "^3.0.1"
+        "video-worker": "^3.1.0"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -18043,9 +18043,9 @@
       "license": "MIT"
     },
     "node_modules/video-worker": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/video-worker/-/video-worker-3.0.1.tgz",
-      "integrity": "sha512-J5a5E2/E3eZfIw+A/uBsEKGmxsIQR3kaw0kOiBsQKyeU8WR+9zFufu6ZFIn4QKhmsAN5Yi2TUxLmBRRQYGfPeg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/video-worker/-/video-worker-3.1.0.tgz",
+      "integrity": "sha512-OyhVS4mmMpopD24eECvmhsXURm5rpofDyTIRIiDfzD2JrdufFer0YaxnR4dXwWzk6k75fTBNp8cY9OuQabHfew==",
       "license": "MIT"
     },
     "node_modules/vinyl": {

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "conditionize": "^1.0.5",
     "deep-assign": "^3.0.0",
     "deep-equal": "^2.2.3",
-    "jarallax": "^3.0.1",
+    "jarallax": "^3.1.0",
     "shorthash": "0.0.2",
     "throttle-debounce": "^5.0.2",
-    "video-worker": "^3.0.1"
+    "video-worker": "^3.1.0"
   }
 }

--- a/src/advanced-backgrounds.php
+++ b/src/advanced-backgrounds.php
@@ -102,8 +102,8 @@ class NK_AWB {
      * Register scripts that will be used in the future when portfolio will be printed.
      */
     public function register_scripts() {
-        wp_register_script( 'jarallax', nk_awb()->plugin_url . 'assets/vendor/jarallax/dist/jarallax.min.js', array(), '3.0.1', true );
-        wp_register_script( 'jarallax-video', nk_awb()->plugin_url . 'assets/vendor/jarallax/dist/jarallax-video.min.js', array( 'jarallax' ), '3.0.1', true );
+        wp_register_script( 'jarallax', nk_awb()->plugin_url . 'assets/vendor/jarallax/dist/jarallax.min.js', array(), '3.1.0', true );
+        wp_register_script( 'jarallax-video', nk_awb()->plugin_url . 'assets/vendor/jarallax/dist/jarallax-video.min.js', array( 'jarallax' ), '3.1.0', true );
         wp_register_script( 'awb', nk_awb()->plugin_url . 'assets/awb/awb.min.js', array( 'jarallax', 'jarallax-video' ), '@@plugin_version', true );
 
         wp_localize_script(


### PR DESCRIPTION
Same shape as the 3.0.1 bump: dependency ranges, lock file, and the two registered script versions in `advanced-backgrounds.php`. The changelog entry belongs to the release commit, so it is not here.

What AWB gets out of it:

- **Vimeo video backgrounds are no longer forced to muted playback in Chrome.** The generated iframe was missing its `allow` attribute, so Chrome denied it the autoplay permission and the player muted itself to be allowed to play. Only matters for backgrounds with a non-zero `videoVolume`.
- **`prefers-reduced-motion` is honoured automatically.** Parallax stops moving and background video is never loaded. AWB's own `disableParallax()` / `disableVideo()` callbacks still work as before — the library ORs the media query with whatever the callback returns, so nothing here needed changing.
- **YouTube embeds move off `youtube-nocookie.com`**, which now asks a share of visitors to sign in before it plays. video-worker 3.1.0 defaults to `youtube.com` and exposes `youtubeHost` / `vimeoHost` instead. This is a visible privacy-behaviour change for backgrounds. If we want to keep the old host reachable, `features/jarallax.js` would need to pass `videoYoutubeHost` through from a data attribute — happy to add that as a follow-up.
- **`data-awb-video-volume="0"`**: jarallax used to read that string as truthy and leave the player unmuted, which blocked background autoplay on mobile. Fixed upstream.

`assets/vendor/jarallax/**` is copied from `node_modules` at build time rather than committed, so there is nothing to re-vendor in this diff.