### PR TITLE
feat(video): add a Privacy-Enhanced Mode toggle for YouTube

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "advanced-backgrounds",
-  "version": "1.12.10",
+  "version": "1.12.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "advanced-backgrounds",
-      "version": "1.12.10",
+      "version": "1.12.11",
       "hasInstallScript": true,
       "license": "GPL-2.0",
       "dependencies": {
@@ -14,10 +14,10 @@
         "conditionize": "^1.0.5",
         "deep-assign": "^3.0.0",
         "deep-equal": "^2.2.3",
-        "jarallax": "^3.0.1",
+        "jarallax": "^3.1.0",
         "shorthash": "0.0.2",
         "throttle-debounce": "^5.0.2",
-        "video-worker": "^3.0.1"
+        "video-worker": "^3.1.0"
       },
       "devDependencies": {
         "@babel/node": "^7.29.0",
@@ -10836,12 +10836,12 @@
       }
     },
     "node_modules/jarallax": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jarallax/-/jarallax-3.0.1.tgz",
-      "integrity": "sha512-CipllEQw7vGt5Mz1bDCoP+1izyoakI6TUuyGIhFJAzP/91FGYVvKlGIY6Ijq3zwxkwJlweezduAvys9RsxcqZA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jarallax/-/jarallax-3.1.0.tgz",
+      "integrity": "sha512-tO6N/CRcB4OXLMm+ZkuKcuVNXzbhU2SS6gziaPczk3zuVuiUKxYZrL9wrdqmV7lgwGoyu6EUOpvWMgqi8eSCTA==",
       "license": "MIT",
       "dependencies": {
-        "video-worker": "^3.0.1"
+        "video-worker": "^3.1.0"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -18043,9 +18043,9 @@
       "license": "MIT"
     },
     "node_modules/video-worker": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/video-worker/-/video-worker-3.0.1.tgz",
-      "integrity": "sha512-J5a5E2/E3eZfIw+A/uBsEKGmxsIQR3kaw0kOiBsQKyeU8WR+9zFufu6ZFIn4QKhmsAN5Yi2TUxLmBRRQYGfPeg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/video-worker/-/video-worker-3.1.0.tgz",
+      "integrity": "sha512-OyhVS4mmMpopD24eECvmhsXURm5rpofDyTIRIiDfzD2JrdufFer0YaxnR4dXwWzk6k75fTBNp8cY9OuQabHfew==",
       "license": "MIT"
     },
     "node_modules/vinyl": {

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "conditionize": "^1.0.5",
     "deep-assign": "^3.0.0",
     "deep-equal": "^2.2.3",
-    "jarallax": "^3.0.1",
+    "jarallax": "^3.1.0",
     "shorthash": "0.0.2",
     "throttle-debounce": "^5.0.2",
-    "video-worker": "^3.0.1"
+    "video-worker": "^3.1.0"
   }
 }

--- a/src/advanced-backgrounds.php
+++ b/src/advanced-backgrounds.php
@@ -102,8 +102,8 @@ class NK_AWB {
      * Register scripts that will be used in the future when portfolio will be printed.
      */
     public function register_scripts() {
-        wp_register_script( 'jarallax', nk_awb()->plugin_url . 'assets/vendor/jarallax/dist/jarallax.min.js', array(), '3.0.1', true );
-        wp_register_script( 'jarallax-video', nk_awb()->plugin_url . 'assets/vendor/jarallax/dist/jarallax-video.min.js', array( 'jarallax' ), '3.0.1', true );
+        wp_register_script( 'jarallax', nk_awb()->plugin_url . 'assets/vendor/jarallax/dist/jarallax.min.js', array(), '3.1.0', true );
+        wp_register_script( 'jarallax-video', nk_awb()->plugin_url . 'assets/vendor/jarallax/dist/jarallax-video.min.js', array( 'jarallax' ), '3.1.0', true );
         wp_register_script( 'awb', nk_awb()->plugin_url . 'assets/awb/awb.min.js', array( 'jarallax', 'jarallax-video' ), '@@plugin_version', true );
 
         wp_localize_script(

--- a/src/assets/admin/gutenberg/block-edit.js
+++ b/src/assets/admin/gutenberg/block-edit.js
@@ -99,6 +99,16 @@ function onImageSelect(media, setAttributes) {
     });
 }
 
+/**
+ * The no-cookie host only exists for YouTube, so the toggle is offered only once the URL is one.
+ *
+ * @param {String} url - video URL.
+ * @return {Boolean}
+ */
+function isYoutubeUrl(url) {
+  return !!url && !!VideoWorker.providers.Youtube.parseURL(url);
+}
+
 const videoPosterCache = {};
 let videoPosterTimeout;
 
@@ -150,6 +160,7 @@ export function RenderInspectorControls(props) {
     videoEndTime,
     videoLoop,
     videoAlwaysPlay,
+    videoYoutubeNoCookie,
     videoMobile,
 
     mediaOpacity,
@@ -254,6 +265,18 @@ export function RenderInspectorControls(props) {
                   onChange={(v) => setAttributes({ video: v })}
                   help={__('Supported YouTube and Vimeo URLs')}
                   __next40pxDefaultSize
+                  __nextHasNoMarginBottom
+                />
+              ) : null}
+
+              {type === 'yt_vm_video' && isYoutubeUrl(video) ? (
+                <ToggleControl
+                  label={__('Privacy-Enhanced Mode')}
+                  help={__(
+                    'Load the video from youtube-nocookie.com. YouTube stores no cookies until playback starts, but some visitors are asked to sign in before the video plays.'
+                  )}
+                  checked={!!videoYoutubeNoCookie}
+                  onChange={(v) => setAttributes({ videoYoutubeNoCookie: v })}
                   __nextHasNoMarginBottom
                 />
               ) : null}

--- a/src/assets/admin/gutenberg/block.json
+++ b/src/assets/admin/gutenberg/block.json
@@ -149,6 +149,10 @@
       "type": "boolean",
       "default": false
     },
+    "videoYoutubeNoCookie": {
+      "type": "boolean",
+      "default": false
+    },
 
     "mediaOpacity": {
       "type": "number",

--- a/src/assets/admin/gutenberg/components/jarallax.js
+++ b/src/assets/admin/gutenberg/components/jarallax.js
@@ -51,6 +51,7 @@ export default function Jarallax({ className = '', ...options }) {
     options.videoVolume,
     options.videoLoop,
     options.videoPlayOnlyVisible,
+    options.videoYoutubeHost,
   ]);
 
   // Destroy Jarallax.

--- a/src/assets/admin/gutenberg/utils/prepare-jarallax-params/index.js
+++ b/src/assets/admin/gutenberg/utils/prepare-jarallax-params/index.js
@@ -43,6 +43,9 @@ export default function prepareJarallaxParams(attrs) {
         if (attrs.videoAlwaysPlay) {
           result.videoAlwaysPlay = attrs.videoAlwaysPlay;
         }
+        if (attrs.videoYoutubeNoCookie) {
+          result.videoYoutubeHost = 'https://www.youtube-nocookie.com';
+        }
         result.videoMobile = attrs.videoMobile;
       }
       break;

--- a/src/assets/awb/features/jarallax.js
+++ b/src/assets/awb/features/jarallax.js
@@ -24,6 +24,7 @@ function prepareJarallax($el) {
   let videoStartTime = 0;
   let videoEndTime = 0;
   let videoVolume = 0;
+  let videoYoutubeNoCookie = false;
   let videoLoop = true;
   let videoAlwaysPlay = true;
   let videoMobile = false;
@@ -39,6 +40,7 @@ function prepareJarallax($el) {
     videoStartTime = parseFloat($el.getAttribute('data-awb-video-start-time')) || 0;
     videoEndTime = parseFloat($el.getAttribute('data-awb-video-end-time')) || 0;
     videoVolume = parseFloat($el.getAttribute('data-awb-video-volume')) || 0;
+    videoYoutubeNoCookie = $el.getAttribute('data-awb-video-youtube-no-cookie') === 'true';
     videoLoop = $el.getAttribute('data-awb-video-loop') !== 'false';
     videoAlwaysPlay = $el.getAttribute('data-awb-video-always-play') === 'true';
     videoMobile =
@@ -93,6 +95,11 @@ function prepareJarallax($el) {
     jarallaxParams.videoEndTime = videoEndTime;
     jarallaxParams.videoVolume = videoVolume;
     jarallaxParams.videoLoop = videoLoop;
+
+    // Opt-in privacy-enhanced host. Left unset, VideoWorker keeps its own default.
+    if (videoYoutubeNoCookie) {
+      jarallaxParams.videoYoutubeHost = 'https://www.youtube-nocookie.com';
+    }
     jarallaxParams.videoPlayOnlyVisible = !videoAlwaysPlay;
   }
 

--- a/src/classes/class-shortcode.php
+++ b/src/classes/class-shortcode.php
@@ -79,6 +79,7 @@ class NK_AWB_Shortcode {
                 'awb_video_volume'              => 0,
                 'awb_video_always_play'         => 'false',
                 'awb_video_mobile'              => 'false',
+                'awb_video_youtube_no_cookie'   => 'false',
 
                 'awb_parallax'                  => 'false', // scroll, scale, opacity, scroll-opacity, scale-opacity.
                 'awb_parallax_speed'            => 0.5,
@@ -174,6 +175,11 @@ class NK_AWB_Shortcode {
             $awb_wrap_attributes .= ' data-awb-video-start-time="' . esc_attr( $atts['awb_video_start_time'] ) . '"';
             $awb_wrap_attributes .= ' data-awb-video-end-time="' . esc_attr( $atts['awb_video_end_time'] ) . '"';
             $awb_wrap_attributes .= ' data-awb-video-volume="' . esc_attr( $atts['awb_video_volume'] ) . '"';
+
+            // youtube privacy-enhanced host.
+            if ( filter_var( $atts['awb_video_youtube_no_cookie'], FILTER_VALIDATE_BOOLEAN ) ) {
+                $awb_wrap_attributes .= ' data-awb-video-youtube-no-cookie="true"';
+            }
 
             // video always play.
             if ( filter_var( $atts['awb_video_always_play'], FILTER_VALIDATE_BOOLEAN ) ) {


### PR DESCRIPTION
Stacked on #71, which is where the jarallax and video-worker 3.1.0 bump lives.

video-worker 3.1.0 stopped hardcoding `youtube-nocookie.com`, because that domain now asks a share of visitors to sign in before it plays anything and leaves the background dead for them. The regular host is the right default, but the privacy-enhanced one was a real feature people were getting without knowing it existed, so it becomes a choice on the block rather than a silent constant.

The toggle sits under the Video URL field in the Video panel and **only appears once the entered URL is a YouTube one** — Vimeo has no equivalent host. The check reuses `VideoWorker.providers.Youtube.parseURL`, which the editor already imports for poster loading, so URL parsing stays in one place.

| toggle | background loaded from |
| :--- | :--- |
| off (default) | `https://www.youtube.com/embed/…` |
| on | `https://www.youtube-nocookie.com/embed/…` |

Wired through the whole chain: block attribute, `awb_video_youtube_no_cookie` shortcode attribute, the `data-awb-video-youtube-no-cookie` attribute emitted for the `yt_vm_video` branch, and `features/jarallax.js` turning it into jarallax's `videoYoutubeHost`. The editor preview picks it up too, including the effect dependency so flipping the toggle re-initializes the preview.

Verified in Chrome 151 by driving the same option construction `features/jarallax.js` uses and reading the resulting iframe `src`.

Existing content is unaffected: the attribute defaults to `false` and the data attribute is only emitted when it is on, matching how `data-awb-video-always-play` already works.

Not touched: the TinyMCE shortcode builder and the VC extension still have no field for it, so those routes keep the default host. Say the word if we want it there too.