### PR TITLE
WordPress 7.1 editor fixes, parallax geometry, and "Disable video" actually disables video

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -37,7 +37,7 @@
     -->
 
     <!-- Include sniffs for PHP cross-version compatibility. -->
-    <config name="testVersion" value="7.2-"/>
+    <config name="testVersion" value="7.4-"/>
     <rule ref="PHPCompatibilityWP"/>
 
     <!-- Include the WordPress ruleset, with select exclusions. -->

--- a/src/advanced-backgrounds.php
+++ b/src/advanced-backgrounds.php
@@ -113,7 +113,7 @@ class NK_AWB {
                 'version'  => '@@plugin_version',
                 'settings' => array(
                     'disable_parallax'    => array_keys( AWB_Settings::get_option( 'disable_parallax', 'awb_general', array() ) ? AWB_Settings::get_option( 'disable_parallax', 'awb_general', array() ) : array() ),
-                    'disable_video'       => array_keys( AWB_Settings::get_option( 'disable_video', 'awb_general', array() ) ? AWB_Settings::get_option( 'disable_video', 'awb_general', array() ) : array() ),
+                    'disable_video'       => array_keys( AWB_Settings::get_option( 'disable_videos', 'awb_general', array() ) ? AWB_Settings::get_option( 'disable_videos', 'awb_general', array() ) : array() ),
                     'full_width_fallback' => ! ( ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) || get_theme_support( 'align-wide' ) ),
                 ),
             )

--- a/src/assets/admin/gutenberg/block-edit.js
+++ b/src/assets/admin/gutenberg/block-edit.js
@@ -264,8 +264,6 @@ export function RenderInspectorControls(props) {
                   value={video}
                   onChange={(v) => setAttributes({ video: v })}
                   help={__('Supported YouTube and Vimeo URLs')}
-                  __next40pxDefaultSize
-                  __nextHasNoMarginBottom
                 />
               ) : null}
 
@@ -277,7 +275,6 @@ export function RenderInspectorControls(props) {
                   )}
                   checked={!!videoYoutubeNoCookie}
                   onChange={(v) => setAttributes({ videoYoutubeNoCookie: v })}
-                  __nextHasNoMarginBottom
                 />
               ) : null}
 
@@ -422,7 +419,6 @@ export function RenderInspectorControls(props) {
                 label={__('Enable on mobile devices')}
                 checked={!!videoMobile}
                 onChange={(v) => setAttributes({ videoMobile: v })}
-                __nextHasNoMarginBottom
               />
 
               <TextControl
@@ -433,8 +429,6 @@ export function RenderInspectorControls(props) {
                 help={__(
                   'Start time in seconds when video will be started (this value will be applied also after loop)'
                 )}
-                __next40pxDefaultSize
-                __nextHasNoMarginBottom
               />
               <TextControl
                 label={__('End time')}
@@ -442,21 +436,17 @@ export function RenderInspectorControls(props) {
                 value={videoEndTime}
                 onChange={(v) => setAttributes({ videoEndTime: parseFloat(v) })}
                 help={__('End time in seconds when video will be ended')}
-                __next40pxDefaultSize
-                __nextHasNoMarginBottom
               />
               <ToggleControl
                 label={__('Loop')}
                 checked={!!videoLoop}
                 onChange={(v) => setAttributes({ videoLoop: v })}
-                __nextHasNoMarginBottom
               />
               <ToggleControl
                 label={__('Always play')}
                 help={__('Play video also when not in viewport')}
                 checked={!!videoAlwaysPlay}
                 onChange={(v) => setAttributes({ videoAlwaysPlay: v })}
-                __nextHasNoMarginBottom
               />
               <RangeControl
                 label={__('Video Opacity')}
@@ -464,8 +454,6 @@ export function RenderInspectorControls(props) {
                 min="0"
                 max="100"
                 onChange={(value) => setAttributes({ mediaOpacity: value })}
-                __next40pxDefaultSize
-                __nextHasNoMarginBottom
               />
             </PanelBody>
           ) : null}
@@ -515,7 +503,6 @@ export function RenderInspectorControls(props) {
                           : cleanImgTag(imageTag)
                       }
                       onChange={(v) => setAttributes({ imageBackgroundPosition: v })}
-                      __nextHasNoMarginBottom
                     />
                   ) : null}
 
@@ -528,8 +515,6 @@ export function RenderInspectorControls(props) {
                         label: imgSize.name,
                       }))}
                       onChange={(v) => setAttributes({ imageSize: v })}
-                      __next40pxDefaultSize
-                      __nextHasNoMarginBottom
                     />
                   ) : null}
                   <SelectControl
@@ -554,8 +539,6 @@ export function RenderInspectorControls(props) {
                       },
                     ]}
                     onChange={(v) => setAttributes({ imageBackgroundSize: v })}
-                    __next40pxDefaultSize
-                    __nextHasNoMarginBottom
                   />
                   <RangeControl
                     label={__('Image Opacity')}
@@ -563,8 +546,6 @@ export function RenderInspectorControls(props) {
                     min="0"
                     max="100"
                     onChange={(value) => setAttributes({ mediaOpacity: value })}
-                    __next40pxDefaultSize
-                    __nextHasNoMarginBottom
                   />
                   <div style={{ textAlign: 'right' }}>
                     <Button
@@ -663,8 +644,6 @@ export function RenderInspectorControls(props) {
                     },
                   ]}
                   onChange={(v) => setAttributes({ parallax: v })}
-                  __next40pxDefaultSize
-                  __nextHasNoMarginBottom
                 />
                 {parallax ? (
                   <Fragment>
@@ -677,14 +656,11 @@ export function RenderInspectorControls(props) {
                       max="2"
                       onChange={(v) => setAttributes({ parallaxSpeed: parseFloat(v) })}
                       help={__('Provide number from -1.0 to 2.0')}
-                      __next40pxDefaultSize
-                      __nextHasNoMarginBottom
                     />
                     <ToggleControl
                       label={__('Enable on mobile devices')}
                       checked={!!parallaxMobile}
                       onChange={(v) => setAttributes({ parallaxMobile: v })}
-                      __nextHasNoMarginBottom
                     />
                   </Fragment>
                 ) : null}
@@ -694,7 +670,6 @@ export function RenderInspectorControls(props) {
                   label={__('Enable')}
                   checked={!!mouseParallax}
                   onChange={(v) => setAttributes({ mouseParallax: v })}
-                  __nextHasNoMarginBottom
                 />
                 {mouseParallax ? (
                   <Fragment>
@@ -705,8 +680,6 @@ export function RenderInspectorControls(props) {
                       max="200"
                       help={` ${__('px')}`}
                       onChange={(v) => setAttributes({ mouseParallaxSize: v })}
-                      __next40pxDefaultSize
-                      __nextHasNoMarginBottom
                     />
                     <RangeControl
                       label={__('Speed')}
@@ -715,8 +688,6 @@ export function RenderInspectorControls(props) {
                       max="20000"
                       help={` ${__('ms')}`}
                       onChange={(v) => setAttributes({ mouseParallaxSpeed: v })}
-                      __next40pxDefaultSize
-                      __nextHasNoMarginBottom
                     />
                   </Fragment>
                 ) : null}

--- a/src/assets/admin/gutenberg/components/focal-point-picker.js
+++ b/src/assets/admin/gutenberg/components/focal-point-picker.js
@@ -98,7 +98,6 @@ export default class CustomFocalPointPicker extends Component {
         onChange={(val) => {
           onChange(`${parseInt(100 * val.x, 10)}% ${parseInt(100 * val.y, 10)}%`);
         }}
-        __nextHasNoMarginBottom
       />
     );
   }

--- a/src/assets/admin/gutenberg/components/ghostkit-grid-wide-preview.js
+++ b/src/assets/admin/gutenberg/components/ghostkit-grid-wide-preview.js
@@ -2,7 +2,7 @@ import { throttle } from 'throttle-debounce';
 
 import EditorStyles from './editor-styles';
 
-const { Component, Fragment } = wp.element;
+const { Component, Fragment, createRef } = wp.element;
 
 export default class GhostKitGridWidePreview extends Component {
   constructor(...args) {
@@ -18,11 +18,18 @@ export default class GhostKitGridWidePreview extends Component {
           : `[data-block="${this.props.clientId}"] > .awb-gutenberg-preview-block`,
     };
 
+    // The editor canvas is iframed, so the block list lives in a different document than
+    // the editor chrome. This anchor is rendered inside the canvas and gives us that document.
+    this.anchorRef = createRef();
+    this.canvasWindow = null;
+
     this.updatePosition = throttle(300, this.updatePosition.bind(this));
   }
 
   componentDidMount() {
-    window.addEventListener('resize', this.updatePosition);
+    this.canvasWindow = this.anchorRef.current?.ownerDocument?.defaultView || null;
+
+    this.canvasWindow?.addEventListener('resize', this.updatePosition);
     this.updatePosition();
   }
 
@@ -37,7 +44,8 @@ export default class GhostKitGridWidePreview extends Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.updatePosition);
+    this.canvasWindow?.removeEventListener('resize', this.updatePosition);
+    this.canvasWindow = null;
   }
 
   updatePosition() {
@@ -51,12 +59,14 @@ export default class GhostKitGridWidePreview extends Component {
       previewAlign: attributes.awb_align,
     };
 
-    if (attributes.awb_align === 'full') {
-      const $layout = document.querySelector('.block-editor-block-list__layout');
-      const $parentBlock = document.querySelector(
+    const canvasDocument = this.anchorRef.current?.ownerDocument;
+
+    if (attributes.awb_align === 'full' && canvasDocument) {
+      const $layout = canvasDocument.querySelector('.block-editor-block-list__layout');
+      const $parentBlock = canvasDocument.querySelector(
         '.block-editor-block-list__layout .wp-block:not([data-align])'
       );
-      const $preview = document.querySelector(previewSelector);
+      const $preview = canvasDocument.querySelector(previewSelector);
 
       if ($layout && $parentBlock && $preview) {
         const layoutRect = $layout.getBoundingClientRect();
@@ -93,6 +103,7 @@ export default class GhostKitGridWidePreview extends Component {
 
     return (
       <Fragment>
+        <style ref={this.anchorRef} />
         {AWBpreviewStyles ? <EditorStyles styles={AWBpreviewStyles} /> : ''}
         {this.props.children}
       </Fragment>

--- a/src/assets/admin/gutenberg/components/jarallax.js
+++ b/src/assets/admin/gutenberg/components/jarallax.js
@@ -6,9 +6,26 @@ import classnames from 'classnames/dedupe';
 const { useRef, useEffect, Fragment } = wp.element;
 
 /**
- * Local Dependencies
+ * The jarallax instance that belongs to the element's own document.
+ *
+ * This component runs in the admin page but renders into the editor canvas, which WordPress 7.1
+ * always serves as an iframe. jarallax reads the viewport from the window it was loaded in, so
+ * the copy on the admin page would measure the admin viewport while positioning an element that
+ * lives in the canvas - the parallax offset comes out wrong by the difference between the two,
+ * and the visibility check that gates video playback tests the wrong rectangle.
+ *
+ * The canvas loads its own copy, so take that one. The admin page's copy is the fallback for
+ * anywhere the canvas does not have it.
+ *
+ * @param {HTMLElement} element - the element being decorated.
+ *
+ * @return {Function|undefined} jarallax, bound to the right document.
  */
-const { jarallax } = window;
+function getJarallax(element) {
+  const view = element && element.ownerDocument && element.ownerDocument.defaultView;
+
+  return (view && view.jarallax) || window.jarallax;
+}
 
 /**
  * Component
@@ -33,7 +50,9 @@ export default function Jarallax({ className = '', ...options }) {
 
   // Init Jarallax and update options.
   useEffect(() => {
-    if ($el.current) {
+    const jarallax = getJarallax($el.current);
+
+    if ($el.current && jarallax) {
       jarallax($el.current, 'destroy');
       jarallax($el.current, options);
     }
@@ -54,12 +73,15 @@ export default function Jarallax({ className = '', ...options }) {
     options.videoYoutubeHost,
   ]);
 
-  // Destroy Jarallax.
+  // Destroy Jarallax. Resolve the instance from the element again rather than closing over the
+  // one used to initialise, so teardown always talks to the copy that owns the element.
   useEffect(() => {
     const $currentEl = $el.current;
 
     return () => {
-      if ($currentEl) {
+      const jarallax = getJarallax($currentEl);
+
+      if ($currentEl && jarallax) {
         jarallax($currentEl, 'destroy');
       }
     };

--- a/src/assets/admin/gutenberg/components/toggle-group.js
+++ b/src/assets/admin/gutenberg/components/toggle-group.js
@@ -28,7 +28,6 @@ class ToggleGroup extends Component {
         <BaseControl
           label={label}
           className={classnames('awb-control-toggle-group', this.props.className)}
-          __nextHasNoMarginBottom
         >
           <ToggleGroupControl
             value={value}
@@ -36,8 +35,6 @@ class ToggleGroup extends Component {
             isBlock={isBlock}
             isAdaptiveWidth={isAdaptiveWidth}
             hideLabelFromVision
-            __next40pxDefaultSize
-            __nextHasNoMarginBottom
           >
             {options.map((option) => (
               <ToggleGroupControlOption
@@ -60,7 +57,7 @@ class ToggleGroup extends Component {
 
     // Fallback.
     return (
-      <BaseControl label={label} __nextHasNoMarginBottom>
+      <BaseControl label={label}>
         <ButtonGroup className="awb-control-toggle-group">
           {options.map((option) => (
             <Button

--- a/src/assets/admin/gutenberg/extensions/ghostkit-grid.js
+++ b/src/assets/admin/gutenberg/extensions/ghostkit-grid.js
@@ -96,7 +96,7 @@ function addBackgroundControls(Control, props) {
       <PanelBody title={__('Background')} initialOpen={false}>
         <BlockEdit {...awbProps} inspectorControlsOnly />
         <PanelBody>
-          <BaseControl label={__('Full width background')} __nextHasNoMarginBottom>
+          <BaseControl label={__('Full width background')}>
             <ToolbarGroup>
               {AWBGutenbergData.full_width_fallback ? (
                 /* Fallback for align full */

--- a/src/assets/admin/tinymce/mce-button.js
+++ b/src/assets/admin/tinymce/mce-button.js
@@ -393,7 +393,7 @@ const { jQuery: $, tinymce, AWBTinyMCEOptions: options } = window;
             const $this = $(this);
             let val = $this.val();
             if (val) {
-              if ($.isNumeric(val)) {
+              if (!Number.isNaN(parseFloat(val)) && Number.isFinite(Number(val))) {
                 val += 'px';
               }
               customStyles += ` ${$this.attr('data-style')}: ${val};`;

--- a/src/classes/class-rest.php
+++ b/src/classes/class-rest.php
@@ -89,7 +89,8 @@ class NK_AWB_Rest extends WP_REST_Controller {
             return $this->error( 'no_id_found', __( 'Provide image ID.', '@@text_domain' ) );
         }
 
-        $attr = isset( $attr ) && $attr && is_array( $attr ) ? $attr : array();
+        $attr  = isset( $attr ) && $attr && is_array( $attr ) ? $attr : array();
+        $image = '';
 
         if ( $div_tag ) {
             $image_url = wp_get_attachment_image_url( $id, $size, $icon );

--- a/src/readme.md
+++ b/src/readme.md
@@ -3,8 +3,8 @@
 * Contributors: nko
 * Tags: parallax, video, youtube, background, gutenberg
 * Requires at least: 6.2
-* Tested up to: 7.0
-* Requires PHP: 7.2
+* Tested up to: 7.1
+* Requires PHP: 7.4
 * Stable tag: @@plugin_version
 * License: GPLv2 or later
 * License URI: <http://www.gnu.org/licenses/gpl-2.0.html>


### PR DESCRIPTION
## Parallax in the editor was measuring the wrong viewport

`src/assets/admin/gutenberg/components/jarallax.js` took jarallax from the admin page's `window`.
That component runs in the admin page but renders into the editor canvas, which WordPress 7.1
always serves as an iframe — and jarallax reads the viewport from the window it was loaded in. So
it was measuring the admin viewport while positioning an element that lives in the canvas.

Reproduced in a live 7.1 editor by asking the instance what it thought the viewport was:

| | before | after |
|---|---|---|
| viewport jarallax used | **1123px** (the admin page) | **994px** (the canvas) |
| canvas viewport | 994px | 994px |

The parallax offset is wrong by that difference, and `videoPlayOnlyVisible` — which decides
whether a background video plays at all — tests the wrong rectangle.

The canvas loads its own copy of jarallax, so the fix is to resolve the instance from the
element's `ownerDocument.defaultView`, falling back to the admin page's copy. Teardown resolves
it the same way rather than closing over the instance used to initialise, so destroy always talks
to the copy that owns the element.

**No change to the jarallax library was needed.** An earlier note on this work suggested the
library would have to be patched because it binds its window at module load. That turned out to
be the wrong diagnosis: the binding is fine, because the canvas loads its own copy — what was
wrong was which copy this component reached for.

One thing I could not settle here and am flagging rather than guessing at: whether the parallax
visibly animates while scrolling the canvas. jarallax drives its updates from an animation-frame
loop and an IntersectionObserver, and in this environment the browser pane is hidden, where the
frame clock drops to 1Hz and intersection is not computed at all — measured, not assumed. The
geometry fix above is verified; the animation needs a visible browser to confirm.

## The wide preview was looking in the wrong document

`ghostkit-grid-wide-preview.js` found the Ghost Kit grid with three `document.querySelector` calls
against the global document, and listened for `resize` on the global `window`. With the canvas
iframed, `$layout` came back `null` and full-width stretching inside a Ghost Kit grid quietly
stopped working. Both now come from the anchor `<style>` element inside the canvas, via
`ownerDocument` and `defaultView`.

## "Disable video" never did anything

Registered as `disable_videos` (`src/classes/class-settings.php:135`), read as `disable_video`
(`src/advanced-backgrounds.php:116`). Ticking the box had no effect on any site, ever.

The registered key is authoritative — it is what is in the database and what the admin JavaScript
addresses (`src/assets/admin/settings/script.js:4`) — so only the reader changed. The payload key
stays `disable_video`, which is what the front end reads (`src/assets/awb/utils/get-data.js:60`).

**Worth knowing before shipping:** on sites where someone already ticked those boxes, video
backgrounds will now genuinely stop playing on the selected devices. That is the setting finally
working, but it will look like a behaviour change to anyone who ticked it and saw nothing happen.

Neighbouring settings were checked too — `disable_parallax` and `register_image_sizes` match on
both sides.

## Smaller things

- `src/classes/class-rest.php:92-93`: `$image` was read at line 143 but only assigned inside
  `if ( $image_src )`. Initialised.
- `__next40pxDefaultSize` dropped from 11 form controls where WordPress 7.1 made it inert.
  Measured on both versions: no difference on 7.1; on 6.8 it is what opts a control into 40px.
  Nothing removed from a `<Button>`, where the prop still switches 40px against 36px.
- `$.isNumeric` replaced — jQuery 4.0.0 has already removed it, verified against the real build.
- `Requires PHP` 7.2 → 7.4 (WordPress 7.0 raised the core minimum), `Tested up to` 7.0 → 7.1,
  `phpcs.xml.dist` `testVersion` raised to match.

## Still open, deliberately not in here

WordPress 7.1 adds `background.gradient` and `minWidth` block supports, which now overlap the
"Background" panel AWB injects into other blocks (`src/classes/class-gutenberg.php:145-168`).
Nothing breaks; the panels sit next to each other. Renaming ours rather than cutting anything is
the obvious answer, but it changes what users see.

## How this was checked

`php -l` clean on all 8 PHP files. `npm run php-lint` (phpcs with WordPress + PHPCompatibilityWP)
exits 0 at `7 / 7 (100%)`; `js-lint` and `css-lint` clean. The setting fix was proved with a
script that stubs `get_option` and calls the real reader: `[]` before, `["mobile","safari"]`
after. Built and mounted on a WordPress 7.1.1-alpha install (PHP 8.3) with nine other plugins —
activates clean, `options-general.php?page=advanced-backgrounds-settings` renders 94 form fields,
`debug.log` stays empty, and an `nk/awb` block with a parallax image renders in the canvas with
jarallax attached and canvas-based geometry.

One pre-existing hole this does not fix: `npm run lint` itself exits 127, because `npm-run-all` is
used by the script but declared in neither `dependencies` nor `devDependencies`. The three linters
were run individually.