### PR TITLE
chore(release): prepare 1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "advanced-backgrounds",
   "title": "Advanced WordPress Backgrounds",
-  "version": "1.12.11",
+  "version": "1.13.0",
   "description": "Parallax, Video, Images Backgrounds",
   "license": "GPL-2.0",
   "author": "nK <https://nkdev.info>",

--- a/src/readme.md
+++ b/src/readme.md
@@ -67,6 +67,16 @@ The manual installation method involves downloading our AWB plugin and uploading
 
 ## Changelog
 
+= 1.13.0 - Aug 26, 2026 =
+
+* added a Privacy-Enhanced Mode toggle for YouTube backgrounds, shown once the entered URL is a YouTube one
+* changed YouTube backgrounds to use the regular YouTube host by default, because the privacy-enhanced host asks a share of visitors to sign in before it plays anything
+* added WordPress 7.1 compatibility
+* fixed the Disable video setting doing nothing when ticked
+* fixed parallax sitting at the wrong offset in the block editor, which also stopped video backgrounds starting there
+* fixed full width stretching inside a Ghost Kit grid in the block editor
+* raised the minimum PHP requirement to 7.4
+
 = 1.12.11 - Jun 9, 2026 =
 
 * fixed Vimeo video backgrounds not playing


### PR DESCRIPTION
Minor rather than patch, for the same reason as Ghost Kit 3.7.0: the YouTube host changes under existing users. `video-worker` 3.1.0 stopped hardcoding `youtube-nocookie.com`, so the regular host becomes the default and the privacy-enhanced one is now a toggle on the block. Anyone who was relying on the old behaviour without knowing it existed has to turn it on.

The changelog lives in `src/readme.md`. The version lives only in `package.json` — the readme's `Stable tag` and the plugin header both carry `@@plugin_version` and are filled at build time — so there is one line to bump, not four.

Nothing is released here. No tag, no deploy.

## Calls worth checking

**The `Disable video` line describes a behaviour change, not only a fix.** The setting is registered as `disable_videos` but was read as `disable_video`, so the box could be ticked with no effect. Any site that ticked it and carried on seeing video will now see video stop.

| Commit | Decision |
| --- | --- |
| `fix(editor): use the jarallax that belongs to the canvas document` | Written as the two symptoms a user sees — wrong parallax offset and video backgrounds not starting in the editor — rather than as one library-resolution fix. |
| `chore(deps): bump jarallax and video-worker to 3.1.0` | The video-worker half is covered by the YouTube lines. The jarallax half got no line: major bump, empty body, no behaviour change I could name. |
| `chore(git): collapse vendored code in diffs` | Dropped. |