### PR TITLE
chore: ignore .specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 npm-debug.log
 .phpcs.xml
 phpcs.xml
+.specs/


### PR DESCRIPTION
Ignores `.specs/`, a scratch folder for planning notes on the branch in progress. It is never committed, so without the line it turns up untracked in every `git status`.

`specs/` without the dot is untouched, so a spec the repository keeps still lands in a commit.