### PR TITLE
fix(rest): write alt="" when the image has no alt text

### DIFF
--- a/src/classes/class-rest.php
+++ b/src/classes/class-rest.php
@@ -113,11 +113,11 @@ class NK_AWB_Rest extends WP_REST_Controller {
             if ( $image_src ) {
                 list( $src, $width, $height ) = $image_src;
 
-                $alt = trim( wp_strip_all_tags( get_post_meta( $id, '_wp_attachment_image_alt', true ) ) );
-
-                if ( $alt ) {
-                    $attr['alt'] = $alt;
-                }
+                // An attachment with no alt text still needs `alt=""`, the way
+                // wp_get_attachment_image() writes it. Leaving the attribute out marks the image
+                // as missing alt text for crawlers and screen readers alike, and the editor saves
+                // this tag into the block content, so the gap ships with the post.
+                $attr['alt'] = trim( wp_strip_all_tags( get_post_meta( $id, '_wp_attachment_image_alt', true ) ) );
 
                 if ( ! isset( $attr['class'] ) ) {
                     $attr['class'] = 'wp-image-' . $id;


### PR DESCRIPTION
The `get_attachment_image` REST endpoint added an `alt` attribute only when the attachment carried alt text:

```php
$alt = trim( wp_strip_all_tags( get_post_meta( $id, '_wp_attachment_image_alt', true ) ) );

if ( $alt ) {
    $attr['alt'] = $alt;
}
```

A decorative background has no alt text, so `$alt` was `''` and the tag came back with no `alt` at all. `wp_get_attachment_image()` writes `alt=""` in exactly that case; the endpoint now does the same.

This is not only an editor-preview detail. `block-edit.js` stores the endpoint's response in the block's `imageTag` attribute, `block-save.js` writes it into post content, and that saved string is what the front end serves. So the missing attribute was persisted per block and shipped.

Against the live endpoint on visualportfolio.com, before the change:

```
GET /wp-json/awb/v1/get_attachment_image/3385?size=full&attr[class]=jarallax-img
<img src=".../background-abstaction-black.svg" class="wp-image-3385 jarallax-img" width="1660" height="1013" />
```

That is byte for byte what sits in the page source, and it accounts for every AWB background on that site, 15 of them on the home page. An SEO crawler reads each one as an image with no alt text.

| Attachment | Before | After |
| --- | --- | --- |
| no alt text | attribute absent | `alt=""` |
| has alt text | `alt="..."` | unchanged |

**Blocks already saved keep their stored markup until someone opens and saves them again.** Fixing the endpoint stops new and re-saved blocks from carrying the gap; it cannot reach content that is already in the database. Rewriting stored markup at render time would mean a regex over every block's output on every request, which costs more than this is worth.

The only caller passes `attr[class]=jarallax-img` and nothing else (`block-edit.js:873`), so no caller-supplied `alt` is being overwritten. A non-empty attachment alt already won over anything a caller passed, and that precedence is unchanged.

**How to check.** Add an AWB background whose attachment has no alt text, save, and look at the rendered `<img>`: it now carries `alt=""`. PHPCS, ESLint and Stylelint are clean.
